### PR TITLE
Make answers case-insensitive

### DIFF
--- a/library.js
+++ b/library.js
@@ -44,7 +44,7 @@ plugin.addCaptcha = function(params, callback) {
 plugin.checkRegister = function(params, callback) {
 	var answer = meta.config['registration-question:answer'];
 
-	if (answer !== params.req.body['registration-question']) {
+	if (answer.toLowerCase() !== params.req.body['registration-question'].toLowerCase()) {
 		callback({source: 'registration-question', message: 'wrong-answer'}, params);
 	} else {
 		callback(null, params);


### PR DESCRIPTION
On my first day with this plugin, it blocked out legitimate registrations from folks who just didn't answer in all lowercase like I expected. This is a simple patch to ignore case :)